### PR TITLE
Add Mongoose schemas for player and team

### DIFF
--- a/models/players.js
+++ b/models/players.js
@@ -1,0 +1,4 @@
+var mongoose = require('mongoose');
+var playerSchema = require('./schemas/playerSchema');
+
+module.exports = mongoose.model('player', playerSchema);

--- a/models/schemas/playerSchema.js
+++ b/models/schemas/playerSchema.js
@@ -1,0 +1,12 @@
+var mongoose = require('mongoose');
+var ObjectId = mongoose.Schema.Types.ObjectId;
+
+module.exports = new mongoose.Schema({
+  name: String,
+  squad_number: Number,
+  position: String,
+  teams: [{ type: ObjectId, ref: 'Team' }],
+  image_thumbnail: String,
+  image: String,
+  image_hash: String
+});

--- a/models/schemas/teamSchema.js
+++ b/models/schemas/teamSchema.js
@@ -1,0 +1,7 @@
+var mongoose = require('mongoose');
+
+module.exports = new mongoose.Schema({
+  name: String,
+  npsl_site_url: String,
+  logo: String
+});

--- a/models/schemas/teamSchema.js
+++ b/models/schemas/teamSchema.js
@@ -2,6 +2,6 @@ var mongoose = require('mongoose');
 
 module.exports = new mongoose.Schema({
   name: String,
-  npsl_site_url: String,
+  site_url: String,
   logo: String
 });

--- a/models/teams.js
+++ b/models/teams.js
@@ -1,0 +1,4 @@
+var mongoose = require('mongoose');
+var teamSchema = require('./schemas/teamSchema');
+
+module.exports = mongoose.model('team', teamSchema);


### PR DESCRIPTION
To support storing team rosters on the app server, adds schemas for
players and teams.

Nothing here is particularly novel - these are adapted from the existing
schemas in the client. The primary addition is a schema for teams and
an array of teams for each player, with an eye towards tracking players
participating in multiple leagues if any groups are that ambitious.