### PR TITLE
Use `findOneAndUpdate` upsert for push token create/update

### DIFF
--- a/controllers/pushTokenController.js
+++ b/controllers/pushTokenController.js
@@ -22,35 +22,30 @@ module.exports = app => {
 
   // creates new push token
   app.post('/api/pushToken', (req, res) => {
-    var newToken = PushTokens(req.body);
-    var tokenString = req.body.pushToken;
-    newToken.lastUsed = new Date()
+    var now = new Date()
       .getTime()
       .toString();
-    getToken(tokenString).then(function (token) {
-      if (token === null) {
-        //token is new
-        newToken.save((error, pushToken) => {
-          error
-            ? res
-              .status(501)
-              .send({error})
-            : res.send(pushToken);
-        });
-      } else {
-        //token already exists, so updating timestamp
-        newToken.findOneAndUpdate({ pushToken: token }, {
-          "$set": {
-            "lastUsed": new Date().getTime().toString()
-          }
-        });
-        res.send(token);
-      }
-    });
-  });
+    var tokenData = Object.assign({}, req.body, { lastUsed: now });
 
-  //validates that a push token doesn't already exist in database
-  function getToken(newPushToken) {
-    return PushTokens.findOne({pushToken: newPushToken});
-  }
+    PushTokens.findOneAndUpdate(
+      { pushToken: tokenData.pushToken },
+      tokenData,
+      {
+        // Return new token if updated (instead of original), create a new
+        // record if none exists. There aren't any defaults in the push token
+        // schema yet, but in case there ever are, setDefaultsOnInsert is
+        // probably the behavior we'd want.
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true
+      },
+      (error, token) => {
+        error
+          ? res
+              .status(501)
+              .send({ error: `Error creating or updating push token ${tokenData.pushToken}: ${error}` })
+          : res.send(token);
+      }
+    );
+  });
 };


### PR DESCRIPTION
`findOneAndUpdate` can combine the work of creating and updating push
tokens into one upsert request. This refactors the POST `/api/pushToken`
handler to take advantage of that.