### PR TITLE
Mongocache

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ let playersController = require("./controllers/playersController");
 let rosterController = require("./controllers/rosterController");
 let goalkeeperNicknameController = require("./controllers/goalkeeperNicknameController");
 
+let config = require("./config");
+
 const port = process.env.PORT || 3000;
 const MONGO_URI = process.env.MONGO_URI;
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+var config = {};
+
+config.cache_timeout = 15 * 60 * 1000; //15 minutes
+
+module.exports = config;

--- a/controllers/playersController.js
+++ b/controllers/playersController.js
@@ -1,5 +1,31 @@
 var Players = require('../models/players');
 var bodyParser = require('body-parser');
+var config = require("../config.js");
+
+var players_cache = {
+  data: null,
+  last_refresh: 0,
+  force_reload: function(res) {
+    var that = this;
+    Players.find((error, players) => {
+      if (error) {
+        that.data = null;
+        that.last_refresh = 0;
+        if(res != null) res.send(error);
+      }
+      that.data = players;
+      that.last_refresh = Date.now();
+      if(res != null) res.send(that.data);
+    });
+  },
+  send_data: function(res) {
+    if(this.last_refresh + config.cache_timeout < Date.now()) {
+      this.force_reload(res);
+    } else {
+      res.send(this.data);
+    }
+  }
+}
 
 module.exports = app => {
   app.use(bodyParser.json());
@@ -11,18 +37,14 @@ module.exports = app => {
 
   // returns all players
   app.get('/api/players', (req, res) => {
-    Players.find((error, players) => {
-      if (error) {
-        res.status(501).send({ error });
-      }
-      res.send(players);
-    });
+    players_cache.send_data(res);
   });
 
   // returns single player by _id
   app.get('/api/players/:id', (req, res) => {
     Players.findById(req.params.id, (error, player) => {
       res.send(song);
+      players_cache.force_reload();
     });
   });
 
@@ -31,6 +53,7 @@ module.exports = app => {
     var newPlayer = Players(req.body);
     newPlayer.save((error, player) => {
       error ? res.status(501).send({ error }) : res.send(player);
+      players_cache.force_reload();
     });
   });
 
@@ -38,6 +61,7 @@ module.exports = app => {
   app.put('/api/players/:id', (req, res) => {
     Players.findByIdAndUpdate(req.params.id, req.body, (error, player) => {
       error ? res.status(501).send({ error }) : res.send(player);
+      players_cache.force_reload();
     });
   });
 
@@ -47,6 +71,7 @@ module.exports = app => {
       error
         ? res.status(501).send({ error })
         : res.send({ message: 'Deleted' + req.params.id });
+      players_cache.force_reload();
     });
   });
 };

--- a/controllers/rosterController.js
+++ b/controllers/rosterController.js
@@ -2,7 +2,6 @@ var Roster = require("../models/roster");
 var bodyParser = require("body-parser");
 var config = require("../config.js");
 
-
 var roster_cache = {
   data: null,
   last_refresh: 0,

--- a/controllers/rosterController.js
+++ b/controllers/rosterController.js
@@ -1,5 +1,32 @@
 var Roster = require("../models/roster");
 var bodyParser = require("body-parser");
+var config = require("../config.js");
+
+
+var roster_cache = {
+  data: null,
+  last_refresh: 0,
+  force_reload: function(res) {
+    var that = this;
+    Roster.find((error, roster) => {
+      if (error) {
+        that.data = null;
+        that.last_refresh = 0;
+        if(res != null) res.send(error);
+      }
+      that.data = roster;
+      that.last_refresh = Date.now();
+      if(res != null) res.send(that.data);
+    });
+  },
+  send_data: function(res) {
+    if(this.last_refresh + config.cache_timeout < Date.now()) {
+      this.force_reload(res);
+    } else {
+      res.send(this.data);
+    }
+  }
+}
 
 module.exports = app => {
   app.use(bodyParser.json());
@@ -11,12 +38,7 @@ module.exports = app => {
 
   // returns rosters
   app.get("/api/roster", (req, res) => {
-    Roster.find((error, roster) => {
-      if (error) {
-        res.status(501).send({error});
-      }
-      res.send(roster);
-    });
+    roster_cache.send_data(res);
   });
 
   // creates roster
@@ -24,6 +46,7 @@ module.exports = app => {
     var newRoster = Roster(req.body);
     newRoster.save((error, roster) => {
       error ? res.status(501).send({error}) : res.send(roster);
+      roster_cache.force_reload();
     });
   });
 
@@ -31,6 +54,7 @@ module.exports = app => {
   app.put("/api/roster/:id", (req, res) => {
     Roster.findByIdAndUpdate(req.params.id, req.body, (error, roster) => {
       error ? res.status(501).send({error}) : res.send(roster);
+      roster_cache.force_reload();
     });
   });
 
@@ -40,6 +64,7 @@ module.exports = app => {
       error
         ? res.status(501).send({error})
         : res.send({message: "Deleted" + req.params.id});
+      roster_cache.force_reload();
     });
   });
 };

--- a/controllers/songController.js
+++ b/controllers/songController.js
@@ -1,6 +1,32 @@
 var Songs = require('../models/songs');
 var Notifications = require('../models/notifications');
 var bodyParser = require('body-parser');
+var config = require("../config.js");
+
+var song_cache = {
+  data: null,
+  last_refresh: 0,
+  force_reload: function(res) {
+    var that = this;
+    Songs.find((error, songs) => {
+      if (error) {
+        that.data = {};
+      }
+      that.data = songs;
+      that.last_refresh = Date.now();
+      if(res != null) res.send(that.data);
+    });
+  },
+  send_data: function(res) {
+    if(this.last_refresh + config.cache_timeout < Date.now()) {
+      console.log("forcing reload");
+      this.force_reload(res);
+    } else {
+      console.log("sending from cache");
+      res.send(this.data);
+    }
+  }
+}
 
 module.exports = app => {
   app.use(bodyParser.json());
@@ -17,12 +43,7 @@ module.exports = app => {
 
   // returns all songs
   app.get('/api/songs', (req, res) => {
-    Songs.find((error, songs) => {
-      if (error) {
-        res.status(501).send({ error });
-      }
-      res.send(songs);
-    });
+    song_cache.send_data(res);
   });
 
   // returns single song by _id
@@ -38,6 +59,7 @@ module.exports = app => {
     newSong.save((error, song) => {
       error ? res.status(501).send({ error }) : res.send(song);
     });
+    song_cache.force_reload();
   });
 
   // updates song
@@ -45,6 +67,7 @@ module.exports = app => {
     Songs.findByIdAndUpdate(req.params.id, req.body, (error, song) => {
       error ? res.status(501).send({ error }) : res.send(song);
     });
+    song_cache.force_reload();
   });
 
   // deletes song
@@ -54,5 +77,6 @@ module.exports = app => {
         ? res.status(501).send({ error })
         : res.send({ message: 'Deleted' + req.params.id });
     });
+    song_cache.force_reload();
   });
 };

--- a/controllers/songbookController.js
+++ b/controllers/songbookController.js
@@ -1,5 +1,31 @@
 var Songbook = require("../models/songbook");
 var bodyParser = require("body-parser");
+var config = require("../config.js");
+
+var songbook_cache = {
+  data: null,
+  last_refresh: 0,
+  force_reload: function(res) {
+    var that = this;
+    Songbook.find((error, songbook) => {
+      if (error) {
+        that.data = null;
+        that.last_refresh = 0;
+        if(res != null) res.send(error);
+      }
+      that.data = songbook;
+      that.last_refresh = Date.now();
+      if(res != null) res.send(that.data);
+    });
+  },
+  send_data: function(res) {
+    if(this.last_refresh + config.cache_timeout < Date.now()) {
+      this.force_reload(res);
+    } else {
+      res.send(this.data);
+    }
+  }
+}
 
 module.exports = app => {
   app.use(bodyParser.json());
@@ -11,12 +37,7 @@ module.exports = app => {
 
   // returns songbooks
   app.get("/api/songbook", (req, res) => {
-    Songbook.find((error, songbook) => {
-      if (error) {
-        res.status(501).send({error});
-      }
-      res.send(songbook);
-    });
+    songbook_cache.send_data(res);
   });
 
   // creates songbook
@@ -24,6 +45,7 @@ module.exports = app => {
     var newSongbook = Songbook(req.body);
     newSongbook.save((error, songbook) => {
       error ? res.status(501).send({error}) : res.send(songbook);
+      songbook_cache.force_reload();
     });
   });
 
@@ -31,6 +53,7 @@ module.exports = app => {
   app.put("/api/songbook/:id", (req, res) => {
     Songbook.findByIdAndUpdate(req.params.id, req.body, (error, songbook) => {
       error ? res.status(501).send({error}) : res.send(songbook);
+      songbook_cache.force_reload();
     });
   });
 
@@ -40,6 +63,7 @@ module.exports = app => {
       error
         ? res.status(501).send({error})
         : res.send({message: "Deleted" + req.params.id});
+        songbook_cache.force_reload();
     });
   });
 };


### PR DESCRIPTION
This adds a basic handrolled caching layer for players, rosters, songbooks, and songs. They will only be updated once every 15 minutes from mongo with this PR. Any updates pushed through the API will automatically invalidate the cache and cause it to be updated immediately. Other controllers (e.g. push notifications) probably don't make sense to cache, so they've been left alone.